### PR TITLE
Add dom size

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,9 +4,12 @@ const path = require('path');
 const perfConfig = require('lighthouse/lighthouse-core/config/perf.json');
 const util = require('util');
 
-const saveMainMetrics = require('./schemas/main_metrics');
-const saveFilmstrip = require('./schemas/filmstrip');
+const debug = require('debug')('lighthouse-response');
+
 const saveAssetsBlockingFmp = require('./schemas/assets_blocking_fmp');
+const saveDomSize = require('./schemas/dom_size');
+const saveFilmstrip = require('./schemas/filmstrip');
+const saveMainMetrics = require('./schemas/main_metrics');
 
 const lighthouseOptions = {
   loadPage: true,
@@ -16,7 +19,9 @@ const lighthouseOptions = {
 
 const targetURL = process.env.URL || 'https://www.google.com';
 
-// Hack?
+/**
+ * @see {@link https://github.com/GoogleChrome/lighthouse/issues/73#issuecomment-309159928}
+**/
 self.setImmediate = function(callback, ...argsForCallback) {
   Promise.resolve().then(() => callback(...argsForCallback));
   return 0;
@@ -24,6 +29,8 @@ self.setImmediate = function(callback, ...argsForCallback) {
 
 lighthouse(targetURL, lighthouseOptions, perfConfig)
   .then((res) => {
+    debug('%o', util.inspect(res, true, null, true));
+
     if (process.env.BIGQUERY_PROJECT_ID) {
       const bigquery = new BigQuery({
         keyFilename: path.join(__dirname, 'client_secret.json'),
@@ -33,6 +40,7 @@ lighthouse(targetURL, lighthouseOptions, perfConfig)
 
       return Promise.all([
         saveAssetsBlockingFmp(dataset, res),
+        saveDomSize(dataset, res),
         saveFilmstrip(dataset, res),
         saveMainMetrics(dataset, res),
       ]);

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/mAiNiNfEcTiOn/lighthouse-ci-poc#readme",
   "dependencies": {
     "@google-cloud/bigquery": "^0.9.6",
+    "debug": "^3.0.1",
     "pwmetrics": "^3.1.1"
   }
 }

--- a/schemas/assets_blocking_fmp.js
+++ b/schemas/assets_blocking_fmp.js
@@ -1,6 +1,8 @@
 const path = require('path');
 const URL = require('url');
 
+const debug = require('debug')('assets_blocking_fmp');
+
 const schema = [
   {
     "mode": "REQUIRED",
@@ -119,6 +121,8 @@ module.exports = function save(dataset, lighthouseRes) {
     totalLinksMs,
     website: lighthouseRes.url,
   };
+
+  debug(data);
 
   return dataset
     .table('assets_blocking_fmp')

--- a/schemas/dom_size.js
+++ b/schemas/dom_size.js
@@ -1,0 +1,101 @@
+const path = require('path');
+const URL = require('url');
+
+const debug = require('debug')('dom_size');
+
+const schema = [
+  {
+    "mode": "REQUIRED",
+    "name": "website",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "build_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "build_system",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "totalDOMNodes",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "timestamp",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "REPEATED",
+    "name": "metrics",
+    "type": "RECORD",
+    "fields": [
+      {
+        "mode": "REQUIRED",
+        "name": "metricName",
+        "type": "STRING"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "metricSnippet",
+        "type": "STRING"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "metricTarget",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "metricValue",
+        "type": "INTEGER"
+      }
+    ]
+  }
+];
+
+function processMetricsList(metricsList) {
+  return metricsList
+    .filter((metric) => metric.title !== 'Total DOM Nodes')
+    .map((metric) => {
+      const { snippet, target, title, value } = metric;
+      const metricValue = parseInt(value.replace(',', ''), 10);
+      const metricTarget = parseInt(target.substr(2).replace(',', ''), 10);
+      
+      return {
+        metricName: title,
+        metricSnippet: snippet,
+        metricTarget,
+        metricValue,
+      };
+    });
+}
+
+module.exports = function save(dataset, lighthouseRes) {
+  const timestamp = new Date(lighthouseRes.generatedTime).getTime();
+  
+  const domSizeAudit = lighthouseRes.reportCategories[0].audits.find(audit => audit.id === 'dom-size');
+
+  const totalDOMNodes = domSizeAudit.result.rawValue;
+  
+  const metrics = processMetricsList(domSizeAudit.result.extendedInfo.value);
+
+  const data = {
+    build_id: process.env.BUILD_ID || 'none',
+    build_system: process.env.BUILD_SYSTEM || 'none',
+    metrics,
+    timestamp,
+    totalDOMNodes,
+    website: lighthouseRes.url,
+  };
+
+  debug(data);
+  
+  return dataset
+    .table('dom_size')
+    .insert(data);
+}

--- a/schemas/filmstrip.js
+++ b/schemas/filmstrip.js
@@ -1,3 +1,5 @@
+const debug = require('debug')('filmstrip');
+
 const schema = [
   {
     "mode": "REQUIRED",
@@ -55,6 +57,8 @@ module.exports = function save(dataset, lighthouseRes) {
     timestamp,
     website: lighthouseRes.url,
   };
+
+  debug(data);
 
   return dataset
     .table('filmstrip')

--- a/schemas/main_metrics.js
+++ b/schemas/main_metrics.js
@@ -1,4 +1,7 @@
 const pwmetrics = require('pwmetrics/lib/metrics');
+
+const debug = require('debug')('main_metrics');
+
 const schema = [
   {
     "mode": "REQUIRED",
@@ -62,6 +65,8 @@ module.exports = function save(dataset, lighthouseRes) {
     timestamp,
     website: lighthouseRes.url,
   };
+
+  debug(data);
 
   return dataset
     .table('main_metrics')


### PR DESCRIPTION
# What does this PR do:

* Adds the package `debug` to be able to trigger debug modes in specific areas via the `DEBUG` env variable
* Changes the existing schemas to use the `debug` package to log the metrics to the output on demand
* Adds the new `dom_size` schema which logs the information about the DOM Size (Nodes, depth, children) into BigQuery
* Adds, to the `index.js`, the new `dom_size` schema to the list of BigQuery processes to store. Also adds the usage of the `debug` package to log the lighthouse response on demand

# Where should the reviewer start:
  - Diffs.
  - Check the new `schemas/dom_size.js`.