### PR TITLE
Add user timings

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,11 @@ const saveAssetsBlockingFmp = require('./schemas/assets_blocking_fmp');
 const saveDomSize = require('./schemas/dom_size');
 const saveFilmstrip = require('./schemas/filmstrip');
 const saveMainMetrics = require('./schemas/main_metrics');
+<<<<<<< HEAD
 const saveOffscreenImagesMetrics = require('./schemas/offscreen_images');
+=======
+const saveUserTimings = require('./schemas/user_timings');
+>>>>>>> Adds the usage of the newly created schema 'user_timings'. Also fixes the debug line of the lighthouse response
 
 const lighthouseOptions = {
   loadPage: true,
@@ -30,7 +34,7 @@ self.setImmediate = function(callback, ...argsForCallback) {
 
 lighthouse(targetURL, lighthouseOptions, perfConfig)
   .then((res) => {
-    debug('%o', util.inspect(res, true, null, true));
+    debug(util.inspect(res, true, null, true));
 
     if (process.env.BIGQUERY_PROJECT_ID) {
       const bigquery = new BigQuery({
@@ -45,6 +49,7 @@ lighthouse(targetURL, lighthouseOptions, perfConfig)
         saveFilmstrip(dataset, res),
         saveMainMetrics(dataset, res),
         saveOffscreenImagesMetrics(dataset, res),
+        saveUserTimings(dataset, res),
       ]);
     }
   })

--- a/index.js
+++ b/index.js
@@ -10,11 +10,8 @@ const saveAssetsBlockingFmp = require('./schemas/assets_blocking_fmp');
 const saveDomSize = require('./schemas/dom_size');
 const saveFilmstrip = require('./schemas/filmstrip');
 const saveMainMetrics = require('./schemas/main_metrics');
-<<<<<<< HEAD
 const saveOffscreenImagesMetrics = require('./schemas/offscreen_images');
-=======
 const saveUserTimings = require('./schemas/user_timings');
->>>>>>> Adds the usage of the newly created schema 'user_timings'. Also fixes the debug line of the lighthouse response
 
 const lighthouseOptions = {
   loadPage: true,

--- a/schemas/user_timings.js
+++ b/schemas/user_timings.js
@@ -1,0 +1,89 @@
+const path = require('path');
+const URL = require('url');
+
+const debug = require('debug')('user_timings');
+
+const schema = [
+  {
+    "mode": "REQUIRED",
+    "name": "website",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "build_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "build_system",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "timestamp",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "REPEATED",
+    "name": "metrics",
+    "type": "RECORD",
+    "fields": [
+      {
+        "mode": "REQUIRED",
+        "name": "metricDuration",
+        "type": "FLOAT"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "metricEndTime",
+        "type": "FLOAT"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "metricName",
+        "type": "STRING"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "metricStartTime",
+        "type": "FLOAT"
+      }
+    ]
+  }
+];
+
+function processMetricsList(metricsList) {
+  return metricsList
+    .filter(metric => !metric.isMark)
+    .map((metric) => {
+      return {
+        metricDuration: metric.duration,
+        metricEndTime: metric.endTime,
+        metricName: metric.name,
+        metricStartTime: metric.startTime,
+      };
+    });
+}
+
+module.exports = function save(dataset, lighthouseRes) {
+  const timestamp = new Date(lighthouseRes.generatedTime).getTime();
+  
+  const userTimingsAudit = lighthouseRes.reportCategories[0].audits.find(audit => audit.id === 'user-timings');
+
+  const metrics = processMetricsList(userTimingsAudit.result.extendedInfo.value);
+
+  const data = {
+    build_id: process.env.BUILD_ID || 'none',
+    build_system: process.env.BUILD_SYSTEM || 'none',
+    metrics,
+    timestamp,
+    website: lighthouseRes.url,
+  };
+
+  debug(data);
+  
+  return dataset
+    .table('user_timings')
+    .insert(data);
+}


### PR DESCRIPTION
# What does this PR do:
* Adds the schema for gathering the User Timing API's metrics
* Adds the usage of the newly created schema `user_timings`. Also fixes the debug line of the lighthouse response

# Where should the reviewer start:
  - Diffs
  - Start on the `schema/user_timings.js`